### PR TITLE
Add context to mutex's pool calls

### DIFF
--- a/mutex_test.go
+++ b/mutex_test.go
@@ -1,6 +1,7 @@
 package redsync
 
 import (
+	"context"
 	"errors"
 	"strconv"
 	"testing"
@@ -145,7 +146,7 @@ func newMockPools(n int) []Pool {
 func getPoolValues(pools []Pool, name string) []string {
 	values := []string{}
 	for _, pool := range pools {
-		conn := pool.Get()
+		conn, _ := pool.GetContext(context.Background())
 		value, err := redis.String(conn.Do("GET", name))
 		conn.Close()
 		if err != nil && err != redis.ErrNil {
@@ -159,7 +160,7 @@ func getPoolValues(pools []Pool, name string) []string {
 func getPoolExpiries(pools []Pool, name string) []int {
 	expiries := []int{}
 	for _, pool := range pools {
-		conn := pool.Get()
+		conn, _ := pool.GetContext(context.Background())
 		expiry, err := redis.Int(conn.Do("PTTL", name))
 		conn.Close()
 		if err != nil && err != redis.ErrNil {
@@ -177,7 +178,7 @@ func clogPools(pools []Pool, mask int, mutex *Mutex) int {
 			n++
 			continue
 		}
-		conn := pool.Get()
+		conn, _ := pool.GetContext(context.Background())
 		_, err := conn.Do("SET", mutex.name, "foobar")
 		conn.Close()
 		if err != nil {

--- a/redis.go
+++ b/redis.go
@@ -1,8 +1,12 @@
 package redsync
 
-import "github.com/gomodule/redigo/redis"
+import (
+	"context"
+
+	"github.com/gomodule/redigo/redis"
+)
 
 // A Pool maintains a pool of Redis connections.
 type Pool interface {
-	Get() redis.Conn
+	GetContext(ctx context.Context) (redis.Conn, error)
 }

--- a/redsync.go
+++ b/redsync.go
@@ -1,6 +1,9 @@
 package redsync
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // Redsync provides a simple method for creating distributed mutexes using multiple Redis connection pools.
 type Redsync struct {
@@ -15,10 +18,11 @@ func New(pools []Pool) *Redsync {
 }
 
 // NewMutex returns a new distributed mutex with given name.
-func (r *Redsync) NewMutex(name string, options ...Option) *Mutex {
+func (r *Redsync) NewMutex(ctx context.Context, name string, options ...Option) *Mutex {
 	m := &Mutex{
 		name:      name,
 		expiry:    8 * time.Second,
+		ctx:       ctx,
 		tries:     32,
 		delayFunc: func(tries int) time.Duration { return 500 * time.Millisecond },
 		factor:    0.01,

--- a/redsync_test.go
+++ b/redsync_test.go
@@ -1,6 +1,7 @@
 package redsync
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -28,7 +29,7 @@ func TestRedsync(t *testing.T) {
 	pools := newMockPools(8)
 	rs := New(pools)
 
-	mutex := rs.NewMutex("test-redsync")
+	mutex := rs.NewMutex(context.Background(), "test-redsync")
 	err := mutex.Lock()
 	if err != nil {
 


### PR DESCRIPTION
Since Go1.7, Redigo admits getting a pool connection with a context.
Now all mutex functions which get a pool connection use GetContext.
This way, we can timeout when we've reached the max amount of
connections open.