### PR TITLE
Make Lock report ErrTaken if a quorum reports NodeTaken errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 go:
   - "1.12"
+  - "1.13"
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: go
 go:
-  - "1.8"
-  - "1.9"
-  - "1.10"
-  - "1.11"
+  - "1.12"
 services:
   - redis-server

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -92,7 +92,7 @@ func TestMutexQuorumWithMinorityError(t *testing.T) {
 		return nil, errors.New("test")
 	}
 
-	mutexes := newTestMutexes(pools, "test-mutex", 1)
+	mutexes := newTestMutexes(pools, "test-mutex-minority", 1)
 	mutex := mutexes[0]
 	mutex.tries = 1
 

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -84,6 +84,25 @@ func TestMutexQuorum(t *testing.T) {
 	}
 }
 
+func TestMutexQuorumWithMinorityError(t *testing.T) {
+	pools := newMockPools(4)
+
+	// Node 1 provokes a RedisError.
+	pools[1].(*redis.Pool).Dial = func() (redis.Conn, error) {
+		return nil, errors.New("test")
+	}
+
+	mutexes := newTestMutexes(pools, "test-mutex", 1)
+	mutex := mutexes[0]
+	mutex.tries = 1
+
+	err := mutex.Lock()
+
+	if err != nil {
+		t.Fatalf("Expected nil, got %q", err)
+	}
+}
+
 func TestMutexNoQuorum(t *testing.T) {
 	pools := newMockPools(4)
 

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -103,7 +103,7 @@ func TestMutexTakenWithMinorityError(t *testing.T) {
 	err := mutex.Lock()
 
 	if err != ErrTaken {
-		t.Fatalf("Expected nil, got %q", err)
+		t.Fatalf("Expected ErrTaken, got %q", err)
 	}
 }
 


### PR DESCRIPTION
When a `RedisError` is reported during a `Lock()`, the function `actOnPoolAsync()` reports a `NoQuorum` error event if a majority reported `NoTaken`.

This MR proposes a solution to fix that, making `Lock()` report `ErrTaken` in that case.