### PR TITLE
Fix: Close a connection after checking for errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.2.1] - 2019-09-16
+### Fixed
+ - Fixed connection close call before evaluating error. Do NOT use versions after v2.0.0 and before v2.2.1

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Install Redsync using the go get command:
 
 The only dependencies are the Go distribution and [Redigo](https://github.com/gomodule/redigo).
 
+NOTICE: Do NOT use versions after v2.0.0 and before v2.2.1
+
 ## Documentation
 
 - [Reference](https://godoc.org/gopkg.in/redsync.v1)

--- a/mutex.go
+++ b/mutex.go
@@ -123,10 +123,10 @@ func (m *Mutex) genValue() (string, error) {
 
 func (m *Mutex) acquire(pool Pool, value string) (bool, error) {
 	conn, err := pool.GetContext(m.ctx)
-	defer conn.Close()
 	if err != nil {
 		return false, err
 	}
+	defer conn.Close()
 	reply, err := redis.String(conn.Do("SET", m.name, value, "NX", "PX", int(m.expiry/time.Millisecond)))
 	if err != nil && err != redis.ErrNil {
 		return false, err
@@ -144,10 +144,10 @@ var deleteScript = redis.NewScript(1, `
 
 func (m *Mutex) release(pool Pool, value string) (bool, error) {
 	conn, err := pool.GetContext(m.ctx)
-	defer conn.Close()
 	if err != nil {
 		return false, err
 	}
+	defer conn.Close()
 	status, err := deleteScript.Do(conn, m.name, value)
 	if err != nil {
 		return false, err
@@ -165,10 +165,10 @@ var touchScript = redis.NewScript(1, `
 
 func (m *Mutex) touch(pool Pool, value string, expiry int) (bool, error) {
 	conn, err := pool.GetContext(m.ctx)
-	defer conn.Close()
 	if err != nil {
 		return false, err
 	}
+	defer conn.Close()
 	status, err := redis.String(touchScript.Do(conn, m.name, value, expiry))
 	if err != nil {
 		return false, err


### PR DESCRIPTION
## [2.2.1] - 2019-09-16
### Fixed
 - Fixed connection close call before evaluating error. Do NOT use versions after v2.0.0 and before v2.2.1
